### PR TITLE
Content updates home and contact pages

### DIFF
--- a/contact/index.html
+++ b/contact/index.html
@@ -108,8 +108,7 @@
                                 <img src="/assets/img/map-placeholder-aust.jpg" alt="Map showing Melbourne office"/>
                             </div>
                             <address>
-                                Level 15<br />
-                                357 Collins St<br />
+                                17/31 Queen Street<br />
                                 Melbourne VIC 3000<br />
                                 Australia                                    
                             </address>

--- a/index.html
+++ b/index.html
@@ -285,8 +285,8 @@
 				<div class="wrap cf">
 					<div class="m-all t-1of2 cf">
 						<h2>Who is Flux?</h2>
-						<p>Flux Federation is a subsidiary of Meridian Energy, New Zealand’s largest energy generator and its fourth largest retailer. CEO Ari Sargent is an industry veteran widely credited with spearheading New Zealand's revolution in energy retailing.</p>
-						<p>After building Powershop into the New Zealand's fastest ever growing company in 2011, Ari has been taking his idea to the world and continues to make waves at the helm of Flux.</p>
+						<p>Flux Federation is a subsidiary of Meridian Energy, New Zealand's largest energy generator and its fourth largest retailer. CEO Ari Sargent is an industry veteran widely credited with spearheading New Zealand's revolution in energy retailing.</p>
+						<p>After building Powershop into New Zealand's fastest ever growing company in 2011, Ari has been taking his idea to the world and continues to make waves at the helm of Flux.</p>
 					</div>
 					<div class="m-all t-1of2 cf">
 						<h2>We're hiring</h2>


### PR DESCRIPTION
Hey Ben, hope you are good

Emily Perry has asked for some text corrections.

a) Updated address for Melbourne on contact/index.html

17/31 Queen Street
Melbourne VIC 3000
Australia

b) On the homepage, second para under 'WHO IS FLUX?' - please delete the word 'the' where is says 'After building Powershop into the New Zealand's...'

c) 3. One the homepage, first para under 'WHO IS FLUX?' - please standardise the apostrophes for consistency in 'New Zealand's' 

Cheers
Wil